### PR TITLE
Remove cross-references in test any/all/some API

### DIFF
--- a/content/shmem_test_all.tex
+++ b/content/shmem_test_all.tex
@@ -32,19 +32,19 @@ corresponding \TYPENAME{} specified by Table \ref{p2psynctypes}.
 \end{apiarguments}
 
 \apidescription{
-    The \FUNC{shmem\_test\_all} routine behaves similarly to
-    \FUNC{shmem\_wait\_until\_all}, but it does not block and returns zero if
+    The \FUNC{shmem\_test\_all} routine indicates whether all entries in the
+    test set specified by \VAR{ivars} and \VAR{status} have satisfied the test
+    condition at the calling \ac{PE}.  This routine does not block and returns zero if
     not all entries in \VAR{ivars} satisfied the test condition.  This routine
     compares each of the \VAR{nelems} elements in the \VAR{ivars} array with
     the value \VAR{cmp\_value} according to the comparison operator \VAR{cmp}
     at the calling \ac{PE}.
     If \VAR{nelems} is 0, the wait set is empty and this routine returns 1.
 
-    The optional \VAR{status} array passed to \FUNC{shmem\_test\_all} has the
-    same behavior as in \FUNC{shmem\_wait\_until\_all} in
-    Section~\ref{subsec:shmem_wait_until_all}.   Each element of \VAR{status}
+    The optional \VAR{status} is a mask array of length \VAR{nelems} where each element
     corresponds to the respective element in \VAR{ivars} and indicates whether
-    the element is excluded from the test set.  If all elements
+    the element is excluded from the test set.  Elements of \VAR{status} set to
+    0 will be included in the test set, and elements set to 1 will be ignored.  If all elements
     in \VAR{status} are set to 1 or \VAR{nelems} is 0, the test set is empty
     and this routine returns 0.  If \VAR{status} is a null pointer, it is
     ignored and all elements in \VAR{ivars} are included in the test set.  The

--- a/content/shmem_test_any.tex
+++ b/content/shmem_test_any.tex
@@ -33,8 +33,9 @@ corresponding \TYPENAME{} specified by Table \ref{p2psynctypes}.
 \end{apiarguments}
 
 \apidescription{
-    The \FUNC{shmem\_test\_any} routine behaves similarly to
-    \FUNC{shmem\_wait\_until\_any}, but it does not block and returns zero if
+    The \FUNC{shmem\_test\_any} routine indicates whether any entry in the
+    test set specified by \VAR{ivars} and \VAR{status} has satisfied the test
+    condition at the calling \ac{PE}.  This routine does not block and returns \CONST{SIZE\_MAX} if
     no entries in \VAR{ivars} satisfied the test condition.  This routine
     compares each of the \VAR{nelems} elements in the \VAR{ivars} array with
     the value \VAR{cmp\_value} according to the comparison operator \VAR{cmp}
@@ -43,11 +44,10 @@ corresponding \TYPENAME{} specified by Table \ref{p2psynctypes}.
     the test condition, a series of calls to \FUNC{shmem\_test\_any} must
     eventually return $i$.
 
-    The optional \VAR{status} array passed to \FUNC{shmem\_test\_any} has the
-    same behavior as in \FUNC{shmem\_wait\_until\_any} in
-    Section~\ref{subsec:shmem_wait_until_any}.   Each element of \VAR{status}
+    The optional \VAR{status} is a mask array of length \VAR{nelems} where each element
     corresponds to the respective element in \VAR{ivars} and indicates whether
-    the element is excluded from the test set.  If all
+    the element is excluded from the test set.  Elements of
+    \VAR{status} set to 0 will be included in the test set, and elements set to 1 will be ignored.  If all
     elements in \VAR{status} are set to 1 or \VAR{nelems} is 0, the test set is
     empty and this routine returns \CONST{SIZE\_MAX}.  If \VAR{status} is a
     null pointer, it is ignored and all

--- a/content/shmem_test_some.tex
+++ b/content/shmem_test_some.tex
@@ -35,13 +35,17 @@ corresponding \TYPENAME{} specified by Table \ref{p2psynctypes}.
 \end{apiarguments}
 
 \apidescription{
-    The \FUNC{shmem\_test\_some} routine behaves similarly to
-    \FUNC{shmem\_wait\_until\_some}, but it does not block and returns zero if
+    The \FUNC{shmem\_test\_some} routine indicates whether at least one entry
+    in the test set specified by \VAR{ivars} and \VAR{status} satisfies the
+    test condition at the calling \ac{PE}.  This routine does not block and returns zero if
     no entries in \VAR{ivars} satisfied the test condition.  This routine
     compares each element of the \VAR{ivars} array in the test set with the
     value \VAR{cmp\_value} according to the comparison operator \VAR{cmp} at
-    the calling \ac{PE}.  The order in which these elements are tested is
-    unspecified.
+    the calling \ac{PE}.  This routine tests all elements of \VAR{ivars} in the
+    test set at least once, and the order in which the elements are tested is
+    unspecified.  If an entry $i$ in \VAR{ivars} within the test set satisfies
+    the test condition, a series of calls to \FUNC{shmem\_test\_some} must
+    eventually return $i$.
 
     Upon return, the \VAR{indices} array contains the indices of the elements
     in the test set that satisfied the test condition during the call to
@@ -57,11 +61,10 @@ corresponding \TYPENAME{} specified by Table \ref{p2psynctypes}.
     condition, a series of calls to \FUNC{shmem\_test\_some} must eventually
     include $i$ in the \VAR{indices} array.
 
-    The optional \VAR{status} array passed to \FUNC{shmem\_test\_some} has the
-    same behavior as in \FUNC{shmem\_wait\_until\_some} in
-    Section~\ref{subsec:shmem_wait_until_some}.   Each element of \VAR{status}
+    The optional \VAR{status} is a mask array of length \VAR{nelems} where each element
     corresponds to the respective element in \VAR{ivars} and indicates whether
-    the element is excluded from the test set.  If all
+    the element is excluded from the test set.  Elements of \VAR{status} set to
+    0 will be included in the test set, and elements set to 1 will be ignored.  If all
     elements in \VAR{status} are set to 1 or \VAR{nelems} is 0, the test set is
     empty and this routine returns 0.  If \VAR{status} is a null pointer, it is ignored and all
     elements in \VAR{ivars} are included in the test set.  The \VAR{ivars},


### PR DESCRIPTION
This removes the cross-references within the wait/test any/all/some API from this PR:
https://github.com/openshmem-org/specification/pull/214

Signed-off-by: David M. Ozog <david.m.ozog@intel.com>