### PR TITLE
Fix typos in wait_until/test all routines

### DIFF
--- a/content/shmem_test_all.tex
+++ b/content/shmem_test_all.tex
@@ -38,7 +38,7 @@ corresponding \TYPENAME{} specified by Table \ref{p2psynctypes}.
     compares each of the \VAR{nelems} elements in the \VAR{ivars} array with
     the value \VAR{cmp\_value} according to the comparison operator \VAR{cmp}
     at the calling \ac{PE}.
-    If \VAR{nelems} is 0, the wait set is empty and this routine returns 1.
+    If \VAR{nelems} is 0, the test set is empty and this routine returns 1.
 
     The optional \VAR{status} array passed to \FUNC{shmem\_test\_all} has the
     same behavior as in \FUNC{shmem\_wait\_until\_all} in

--- a/content/shmem_wait_until_all.tex
+++ b/content/shmem_wait_until_all.tex
@@ -46,7 +46,7 @@ corresponding \TYPENAME{} specified by Table~\ref{p2psynctypes}.
     \VAR{status} set to 0 will be included in the wait set, and elements set to
     1 will be ignored.  If all elements in \VAR{status} are set to 1 or
     \VAR{nelems} is 0, the wait set is empty and this routine returns
-    \CONST{SIZE\_MAX}.  If \VAR{status} is a null pointer, it is ignored and
+    immediately.  If \VAR{status} is a null pointer, it is ignored and
     all elements in \VAR{ivars} are included in the wait set.  The \VAR{ivars}
     and \VAR{status} arrays must not overlap in memory.
 }


### PR DESCRIPTION
@jdinan, I found these typos while removing the cross references in PR https://github.com/openshmem-org/specification/pull/214

These are dumb mistakes, but fixing them (in particular, the `SIZE_MAX` return value) is a semantic change, right?  So could this be a doc edit, or should I post a separate proposal?