### PR TITLE
Sessions: same AMO hint

### DIFF
--- a/content/shmem_ctx_session_start.tex
+++ b/content/shmem_ctx_session_start.tex
@@ -97,6 +97,32 @@ void @\FuncDecl{shmem\_ctx\_session\_start}@(shmem_ctx_t ctx, long options, cons
     about \VAR{shmem\_ctx\_session\_config\_t} parameters.
     } \hline
 
+\sessiontablerow{\LibConstRef{SHMEM\_CTX\_SESSION\_SAME\_AMO}}{
+    The \VAR{SHMEM\_CTX\_SESSION\_SAME\_AMO} hint indicates the session will contain
+    a series of calls to AMO and/or signaling routines that do not differ in
+    their signal operators (see Section \ref{subsec:signal_operator}), atomic
+    operations (see Section \ref{sec:amo}), or datatypes (see
+    Tables~\ref{stdamotypes} and \ref{extamotypes}).
+    For example, this hint would apply to a session that includes \textit{only}
+    calls to \FUNC{shmem\_int\_atomic\_inc}.
+    However, this hint would not apply to a session that includes both calls to
+    \FUNC{shmem\_int\_atomic\_inc} and \FUNC{shmem\_int\_atomic\_fetch},
+    because the operation \textit{fetch} differs from \textit{increment}.
+    (Similarly, this hint would not apply to a session that includes both calls to
+    \FUNC{shmem\_int\_atomic\_inc} and \FUNC{shmem\_long\_atomic\_inc},
+    because the datatype \textit{long} differs from \textit{int}.)
+    The \VAR{SHMEM\_CTX\_SESSION\_SAME\_AMO} hint is applicable to sessions that
+    exclusively use \textit{either} the \VAR{SHMEM\_SIGNAL\_SET} or the
+    \VAR{SHMEM\_SIGNAL\_ADD} operators in signaling operations, but not both.
+    This hint does not restrict the application from calling other (non-atomic)
+    RMA routines within the session.
+
+    The \VAR{total\_ops} field of \VAR{config} indicates the expected maximum
+    number of calls to \openshmem RMA routines within the session.
+    See Section~\ref{subsec:shmem_ctx_session_config_t} for details about
+    \VAR{shmem\_ctx\_session\_config\_t} parameters.
+    } \hline
+
 \sessiontableend
 
 \apinotes{

--- a/content/shmem_ctx_session_start.tex
+++ b/content/shmem_ctx_session_start.tex
@@ -98,24 +98,20 @@ void @\FuncDecl{shmem\_ctx\_session\_start}@(shmem_ctx_t ctx, long options, cons
     } \hline
 
 \sessiontablerow{\LibConstRef{SHMEM\_CTX\_SESSION\_SAME\_AMO}}{
-    The \VAR{SHMEM\_CTX\_SESSION\_SAME\_AMO} hint indicates the session will contain
-    a series of calls to AMO and/or signaling routines that do not differ in
-    their signal operators (see Section \ref{subsec:signal_operator}), atomic
-    operations (see Section \ref{sec:amo}), or datatypes (see
-    Tables~\ref{stdamotypes} and \ref{extamotypes}).
-    For example, this hint would apply to a session that includes \textit{only}
-    calls to \FUNC{shmem\_int\_atomic\_inc}.
+    The \VAR{SHMEM\_CTX\_SESSION\_SAME\_AMO} hint indicates the session will
+    contain a series of calls to AMO routines where each call performs the same
+    atomic operation (e.g., using only the \textit{increment} operation) on the
+    same datatype (e.g., only on objects of type \textit{int}).
+    As a more specific example, this hint would apply to a session that
+    includes \textit{only} calls to \FUNC{shmem\_int\_atomic\_inc}.
     However, this hint would not apply to a session that includes both calls to
     \FUNC{shmem\_int\_atomic\_inc} and \FUNC{shmem\_int\_atomic\_fetch},
     because the operation \textit{fetch} differs from \textit{increment}.
     (Similarly, this hint would not apply to a session that includes both calls to
     \FUNC{shmem\_int\_atomic\_inc} and \FUNC{shmem\_long\_atomic\_inc},
     because the datatype \textit{long} differs from \textit{int}.)
-    The \VAR{SHMEM\_CTX\_SESSION\_SAME\_AMO} hint is applicable to sessions that
-    exclusively use \textit{either} the \VAR{SHMEM\_SIGNAL\_SET} or the
-    \VAR{SHMEM\_SIGNAL\_ADD} operators in signaling operations, but not both.
-    This hint does not restrict the application from calling other (non-atomic)
-    RMA routines within the session.
+    This hint does not restrict the application from calling other RMA and/or
+    signaling routines within the session.
 
     The \VAR{total\_ops} field of \VAR{config} indicates the expected maximum
     number of calls to \openshmem RMA routines within the session.

--- a/example_code/shmem_ctx_session_example.c
+++ b/example_code/shmem_ctx_session_example.c
@@ -28,8 +28,9 @@ int main(void) {
   long config_mask;
   config.total_ops = N_UPDATES;
   config_mask = SHMEM_CTX_SESSION_TOTAL_OPS;
+  long options = SHMEM_CTX_SESSION_BATCH | SHMEM_CTX_SESSION_SAME_AMO;
 
-  shmem_ctx_session_start(ctx, SHMEM_CTX_SESSION_BATCH, &config, config_mask);
+  shmem_ctx_session_start(ctx, options, &config, config_mask);
 
   for (size_t i = 0; i < N_UPDATES; i++) {
       int random_pe = rand() % npes;


### PR DESCRIPTION
The `SHMEM_CTX_SESSION_SAME_AMO` hint was pulled out of #493 so we can focus on it separately in this PR.  Please note this PR depends on the branch `wip/sessions` in #493.