### PR TITLE
Collectives: match the textwidth of new text (v1.6)

### DIFF
--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -287,8 +287,8 @@ where \TYPE{} is one of the integer, real, or complex types supported for the PR
     participate in the collective.
     The \source{} and \dest{} arguments must either be the same symmetric
     address, or two different symmetric addresses corresponding to buffers that
-    do not overlap in memory. That is, they must be completely overlapping (sometimes referred to as an ``in place'' reduction) or
-    completely disjoint.
+    do not overlap in memory. That is, they must be completely overlapping (sometimes referred
+    to as an ``in place'' reduction) or completely disjoint.
 
     Team-based reduction routines operate over all \acp{PE} in the provided team argument. All
     \acp{PE} in the provided team must participate in the reduction.


### PR DESCRIPTION
This simply adjusts the text-width of some new text about in-place collectives.  (Sometimes reading diffs is cleaner by ignoring the textwidth, so perhaps we can clean that up a bit for v1.6 while pursuing the changes since v1.5).

It's not an important change, so also this PR serves as an example for section committee members: @kwaters4 @BKP @isubsmith @maawad.  Note that the target branch is `collectives_section-v1.6` on my fork.