### PR TITLE
collectives: clarify src buffer entry requirements

### DIFF
--- a/content/shmem_alltoall.tex
+++ b/content/shmem_alltoall.tex
@@ -105,11 +105,11 @@ void @\FuncDecl{shmem\_alltoall64}@(void *dest, const void *source, size_t nelem
     \begin{itemize}
         \item The \dest{} array on all \acp{PE} in the team is ready to
             accept the result of the operation.
-        \item The \source{} buffer at the local \ac{PE} is ready to be
+        \item The \source{} array at the local \ac{PE} is ready to be
             read by any \ac{PE} in the team.
     \end{itemize}
     The application does not need to synchronize to ensure that the \source{}
-    buffer is ready across all \acp{PE} prior to calling this routine.
+    array is ready across all \acp{PE} prior to calling this routine.
 
     Upon return from a \FUNC{shmem\_alltoall} routine, the following is true for
     the local PE:

--- a/content/shmem_alltoall.tex
+++ b/content/shmem_alltoall.tex
@@ -100,12 +100,16 @@ void @\FuncDecl{shmem\_alltoall64}@(void *dest, const void *source, size_t nelem
     If \VAR{team} compares equal to \LibConstRef{SHMEM\_TEAM\_INVALID} or is
     otherwise invalid, the behavior is undefined.
 
-    Before any \ac{PE} calls a \FUNC{shmem\_alltoall} routine,
-    the following conditions must be ensured:
+    Before any \ac{PE} calls a \FUNC{shmem\_alltoall} routine, the following
+    conditions must be ensured, otherwise the behavior is undefined:
     \begin{itemize}
-    	\item The \VAR{dest} data object on all \acp{PE} in the team is
-    	ready to accept the \FUNC{shmem\_alltoall} data.
+        \item The \dest{} array on all \acp{PE} in the team is ready to
+            accept the result of the operation.
+        \item The \source{} buffer at the local \ac{PE} is ready to be
+            read by any \ac{PE} in the team.
     \end{itemize}
+    The application does not need to synchronize to ensure that the \source{}
+    buffer is ready across all \acp{PE} prior to calling this routine.
 
     Upon return from a \FUNC{shmem\_alltoall} routine, the following is true for
     the local PE:

--- a/content/shmem_broadcast.tex
+++ b/content/shmem_broadcast.tex
@@ -85,13 +85,16 @@ void @\FuncDecl{shmem\_broadcast64}@(void *dest, const void *source, size_t nele
       the team.
     \end{itemize}
 
-    Before any \ac{PE} calls a broadcast routine, the following
-    conditions must be ensured:
+    Before any \ac{PE} calls a broadcast routine, the following conditions
+    must be ensured, otherwise the behavior is undefined:
     \begin{itemize}
-    \item The \dest{} array on all \acp{PE} participating in the broadcast
-      is ready to accept the broadcast data.
-	\end{itemize}
-    Otherwise, the behavior is undefined. 
+        \item The \dest{} array on all \acp{PE} in the team is ready to
+            accept the result of the operation.
+        \item The \source{} buffer at the local root \ac{PE} is ready to be
+            read by any \ac{PE} in the team.
+    \end{itemize}
+    The application does not need to synchronize to ensure that the \source{}
+    buffer is ready across all \acp{PE} prior to calling this routine.
 
 	Upon return from a team-based broadcast routine, the following are true for the local
     \ac{PE}:

--- a/content/shmem_broadcast.tex
+++ b/content/shmem_broadcast.tex
@@ -90,11 +90,11 @@ void @\FuncDecl{shmem\_broadcast64}@(void *dest, const void *source, size_t nele
     \begin{itemize}
         \item The \dest{} array on all \acp{PE} in the team is ready to
             accept the result of the operation.
-        \item The \source{} buffer at the local root \ac{PE} is ready to be
+        \item The \source{} array at the local root \ac{PE} is ready to be
             read by any \ac{PE} in the team.
     \end{itemize}
     The application does not need to synchronize to ensure that the \source{}
-    buffer is ready across all \acp{PE} prior to calling this routine.
+    array is ready across all \acp{PE} prior to calling this routine.
 
 	Upon return from a team-based broadcast routine, the following are true for the local
     \ac{PE}:

--- a/content/shmem_collect.tex
+++ b/content/shmem_collect.tex
@@ -88,6 +88,17 @@ void @\FuncDecl{shmem\_fcollect64}@(void *dest, const void *source, size_t nelem
     If \VAR{team} compares equal to \LibConstRef{SHMEM\_TEAM\_INVALID} or is
     otherwise invalid, the behavior is undefined.
 
+    Before any \ac{PE} calls a collect routine, the following conditions must
+    be ensured, otherwise the behavior is undefined:
+    \begin{itemize}
+        \item The \dest{} array on all \acp{PE} in the team is ready to
+            accept the result of the operation.
+        \item The \source{} buffer at the local \ac{PE} is ready to be read
+            by any \ac{PE} in the team.
+    \end{itemize}
+    The application does not need to synchronize to ensure that the \source{}
+    buffer is ready across all \acp{PE} prior to calling this routine.
+
 \begin{DeprecateBlock}
     \openshmem \FUNC{collect} and \FUNC{fcollect} routines perform a collective
     operation to concatenate \VAR{nelems}

--- a/content/shmem_collect.tex
+++ b/content/shmem_collect.tex
@@ -93,11 +93,11 @@ void @\FuncDecl{shmem\_fcollect64}@(void *dest, const void *source, size_t nelem
     \begin{itemize}
         \item The \dest{} array on all \acp{PE} in the team is ready to
             accept the result of the operation.
-        \item The \source{} buffer at the local \ac{PE} is ready to be read
+        \item The \source{} array at the local \ac{PE} is ready to be read
             by any \ac{PE} in the team.
     \end{itemize}
     The application does not need to synchronize to ensure that the \source{}
-    buffer is ready across all \acp{PE} prior to calling this routine.
+    array is ready across all \acp{PE} prior to calling this routine.
 
 \begin{DeprecateBlock}
     \openshmem \FUNC{collect} and \FUNC{fcollect} routines perform a collective

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -295,12 +295,16 @@ where \TYPE{} is one of the integer, real, or complex types supported for the PR
     If \VAR{team} compares equal to \LibConstRef{SHMEM\_TEAM\_INVALID} or is
     otherwise invalid, the behavior is undefined.
 
-    Before any \ac{PE} calls a reduction routine, the following conditions must be ensured:
+    Before any \ac{PE} calls a reduction routine, the following conditions
+    must be ensured, otherwise the behavior is undefined:
     \begin{itemize}
-    \item The \dest{} array on all \acp{PE} participating in the reduction
-      is ready to accept the results of the \OPR{reduction}.
+        \item The \dest{} array on all \acp{PE} in the team is ready to
+            accept the results of the operation.
+        \item The \source{} buffer at the local \ac{PE} is ready to be read by
+            any \ac{PE} in the team.
     \end{itemize}
-    Otherwise, the behavior is undefined.
+    The application does not need to synchronize to ensure that the \source{}
+    buffer is ready across all \acp{PE} prior to calling this routine.
     
     Upon return from a reduction routine, the following are true for the local
     \ac{PE}:

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -300,11 +300,11 @@ where \TYPE{} is one of the integer, real, or complex types supported for the PR
     \begin{itemize}
         \item The \dest{} array on all \acp{PE} in the team is ready to
             accept the results of the operation.
-        \item The \source{} buffer at the local \ac{PE} is ready to be read by
+        \item The \source{} array at the local \ac{PE} is ready to be read by
             any \ac{PE} in the team.
     \end{itemize}
     The application does not need to synchronize to ensure that the \source{}
-    buffer is ready across all \acp{PE} prior to calling this routine.
+    array is ready across all \acp{PE} prior to calling this routine.
     
     Upon return from a reduction routine, the following are true for the local
     \ac{PE}:

--- a/content/shmem_scan.tex
+++ b/content/shmem_scan.tex
@@ -91,11 +91,11 @@ by Table \ref{teamreducetypes}.
   \begin{itemize}
       \item The \dest{} array on all \acp{PE} in the team is ready to accept
           the result of the operation.
-      \item The \source{} buffer at the local \ac{PE} is ready to be read by
+      \item The \source{} array at the local \ac{PE} is ready to be read by
           any \ac{PE} in the team.
   \end{itemize}
   The application does not need to synchronize to ensure that the \source{}
-  buffer is ready across all \acp{PE} prior to calling this routine.
+  array is ready across all \acp{PE} prior to calling this routine.
   
   Upon return from a scan routine, the following are true for the
   local \ac{PE}: the \dest{} array is updated, and the \source{} array

--- a/content/shmem_scan.tex
+++ b/content/shmem_scan.tex
@@ -86,9 +86,16 @@ by Table \ref{teamreducetypes}.
   \LibConstRef{SHMEM\_TEAM\_INVALID} or is otherwise invalid, the
   behavior is undefined.
 
-  Before any \ac{PE} calls a scan routine, the \dest{} array on all
-  \acp{PE} participating in the operation must be ready to accept the
-  results of the operation.  Otherwise, the behavior is undefined.
+  Before any \ac{PE} calls a scan routine, the following conditions must be
+  ensured, otherwise the behavior is undefined:
+  \begin{itemize}
+      \item The \dest{} array on all \acp{PE} in the team is ready to accept
+          the result of the operation.
+      \item The \source{} buffer at the local \ac{PE} is ready to be read by
+          any \ac{PE} in the team.
+  \end{itemize}
+  The application does not need to synchronize to ensure that the \source{}
+  buffer is ready across all \acp{PE} prior to calling this routine.
   
   Upon return from a scan routine, the following are true for the
   local \ac{PE}: the \dest{} array is updated, and the \source{} array


### PR DESCRIPTION
# Summary of changes
This attempts to clarify the source buffer requirements upon entry to collectives and aligns the text across all relevant collective routines.  The discussion arose from https://github.com/openshmem-org/specification/pull/488

# Proposal Checklist
- [x] Link to issue(s)
- [ ] Changelog entry
- [ ] Reviewed for changes to front matter
- [ ] Reviewed for changes to back matter