### PR TITLE
Pr/associativity of reductions

### DIFF
--- a/content/programming_model_overview.tex
+++ b/content/programming_model_overview.tex
@@ -157,7 +157,7 @@ An overview of the \openshmem routines is described below:
       of concatenated symmetric objects contributed by each of the \acp{PE} in
       another symmetric data object.
   \item \OPR{Reduction}: All \acp{PE} participating in the routine get the result
-      of an associative binary routine over elements of the specified symmetric
+      of a binary operation over elements of the specified symmetric
       data object on another symmetric data object.
   \item \OPR{All-to-All}: All \acp{PE} participating in the routine exchange
       a fixed amount of contiguous or strided data with all other participating

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -394,8 +394,8 @@ where \TYPE{} is one of the integer, real, or complex types supported for the PR
   Zero on successful local completion. Nonzero otherwise.
 }
 
-\parimpnotes{
-    Implementors are encouraged to ensure that repitition of a given \openshmem
+\apiimpnotes{
+    Implementers are encouraged to ensure that repetition of a given \openshmem
     reduction across \textit{different} jobs configurations will yield bitwise
     identical results in the \dest{} arrays of all \acp{PE} in the team.
 }
@@ -403,7 +403,7 @@ where \TYPE{} is one of the integer, real, or complex types supported for the PR
 \begin{apiexamples}
 
 \apicexample
-    {In the following \Cstd[11] example, each \ac{PE} intializes an array of
+    {In the following \Cstd[11] example, each \ac{PE} initializes an array of
     random integers with values between $0$ and $npes-1$, inclusively.  An OR
     reduction then tracks the array indices where maximal values occur (maximal
     values equal $npes - 1$), and a SUM reduction counts the total number of

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -275,7 +275,7 @@ where \TYPE{} is one of the integer, real, or complex types supported for the PR
 \apidescription{
     \openshmem reduction routines are collective routines over an
     existing \openshmem team that compute one or more reductions across symmetric
-    arrays on multiple \acp{PE}.  A reduction performs an associative binary routine
+    arrays on multiple \acp{PE}.  A reduction performs an binary operation
     across a set of values.
 
     The \VAR{nreduce} argument determines the number of separate reductions to
@@ -315,7 +315,7 @@ where \TYPE{} is one of the integer, real, or complex types supported for the PR
 \begin{DeprecateBlock}
     \openshmem reduction routines are collective routines over an active set 
 	that compute one or more reductions across symmetric
-    arrays on multiple \acp{PE}.  A reduction performs an associative binary routine
+    arrays on multiple \acp{PE}.  A reduction performs an binary operation
     across a set of values.
 
     The \VAR{nreduce} argument determines the number of separate reductions to
@@ -370,6 +370,17 @@ where \TYPE{} is one of the integer, real, or complex types supported for the PR
     when \CONST{\_\_STDC\_NO\_COMPLEX\_\_} is defined to 1}, an \openshmem
     implementation is not required to provide support for these
     complex-typed interfaces.
+
+    The binary operations performed by \openshmem reductions are intended to be
+    associative and commutative for utility and reproducibility, but in
+    practice these properties are not strictly required.
+    When applying a reduction to floating-point numbers, the binary operation
+    may not be exactly associative and/or commutative due to the inherent
+    inaccuracies of floating-point arithmetic caused by rounding errors and
+    finite precision.
+    This can lead to slight variations in the result of \openshmem reductions
+    on floating-point datatypes, especially when the number of elements is
+    large and/or when values have highly varying magnitudes.
 }
 
 \apireturnvalues{

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -378,10 +378,26 @@ where \TYPE{} is one of the integer, real, or complex types supported for the PR
     finite precision.
     This can lead to variations in the result of \openshmem arithmetic reduction operations
     on floating-point datatypes.
+
+    Each \ac{PE} in the team must produce a \dest{} array that is bitwise
+    identical to the \dest{} arrays produced by all other \acp{PE} in the team.
+
+    The result of any given \openshmem reduction is reproducible across job
+    execution environments.
+    In other words, repetition of the same reduction operation on the same
+    input \source{} array, same team, and same overall job configuration must
+    yield bitwise identical results across all \dest{} arrays of the \acp{PE}
+    in the team.
 }
 
 \apireturnvalues{
   Zero on successful local completion. Nonzero otherwise.
+}
+
+\parimpnotes{
+    Implementors are encouraged to ensure that repitition of a given \openshmem
+    reduction across \textit{different} jobs configurations will yield bitwise
+    identical results in the \dest{} arrays of all \acp{PE} in the team.
 }
 
 \begin{apiexamples}

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -315,7 +315,7 @@ where \TYPE{} is one of the integer, real, or complex types supported for the PR
 \begin{DeprecateBlock}
     \openshmem reduction routines are collective routines over an active set 
 	that compute one or more reductions across symmetric
-    arrays on multiple \acp{PE}.  A reduction performs an binary operation
+    arrays on multiple \acp{PE}.  A reduction performs a binary operation
     across a set of values.
 
     The \VAR{nreduce} argument determines the number of separate reductions to

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -275,7 +275,7 @@ where \TYPE{} is one of the integer, real, or complex types supported for the PR
 \apidescription{
     \openshmem reduction routines are collective routines over an
     existing \openshmem team that compute one or more reductions across symmetric
-    arrays on multiple \acp{PE}.  A reduction performs an binary operation
+    arrays on multiple \acp{PE}.  A reduction performs a binary operation
     across a set of values.
 
     The \VAR{nreduce} argument determines the number of separate reductions to

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -372,15 +372,12 @@ where \TYPE{} is one of the integer, real, or complex types supported for the PR
     complex-typed interfaces.
 
     The binary operations performed by \openshmem reductions are intended to be
-    associative and commutative for utility and reproducibility, but in
-    practice these properties are not strictly required.
-    When applying a reduction to floating-point numbers, the binary operation
-    may not be exactly associative and/or commutative due to the inherent
-    inaccuracies of floating-point arithmetic caused by rounding errors and
+    associative and commutative.
+    However, floating point arithmetic is not associative or commutative due to the inherent
+    inaccuracies of floating-point representations caused by rounding errors and
     finite precision.
-    This can lead to slight variations in the result of \openshmem reductions
-    on floating-point datatypes, especially when the number of elements is
-    large and/or when values have highly varying magnitudes.
+    This can lead to variations in the result of \openshmem arithmetic reduction operations
+    on floating-point datatypes.
 }
 
 \apireturnvalues{

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -381,13 +381,6 @@ where \TYPE{} is one of the integer, real, or complex types supported for the PR
 
     Each \ac{PE} in the team must produce a \dest{} array that is bitwise
     identical to the \dest{} arrays produced by all other \acp{PE} in the team.
-
-    The result of any given \openshmem reduction is reproducible across job
-    execution environments.
-    In other words, repetition of the same reduction operation on the same
-    input \source{} array, same team, and same overall job configuration must
-    yield bitwise identical results across all \dest{} arrays of the \acp{PE}
-    in the team.
 }
 
 \apireturnvalues{
@@ -396,8 +389,8 @@ where \TYPE{} is one of the integer, real, or complex types supported for the PR
 
 \apiimpnotes{
     Implementers are encouraged to ensure that repetition of a given \openshmem
-    reduction across \textit{different} jobs configurations will yield bitwise
-    identical results in the \dest{} arrays of all \acp{PE} in the team.
+    reduction within a job yields bitwise identical results in the \dest{}
+    arrays of all \acp{PE} in the team.
 }
 
 \begin{apiexamples}


### PR DESCRIPTION
# Summary of changes
This reopens https://github.com/davidozog/openshmem-specification/pull/12 to target RC2.

The latest commit, 3519cfd01a821ec81c373a62b47f9a2065b725fc addresses feedback from WG/committee reviews. 

# Proposal Checklist
- [X] Link to issue(s)
- [ ] Changelog entry
- [ ] Reviewed for changes to front matter
- [ ] Reviewed for changes to back matter
