### PR TITLE
reductions: add note about FP associativity

### DIFF
--- a/content/programming_model_overview.tex
+++ b/content/programming_model_overview.tex
@@ -157,7 +157,7 @@ An overview of the \openshmem routines is described below:
       of concatenated symmetric objects contributed by each of the \acp{PE} in
       another symmetric data object.
   \item \OPR{Reduction}: All \acp{PE} participating in the routine get the result
-      of an associative binary routine over elements of the specified symmetric
+      of a binary operation over elements of the specified symmetric
       data object on another symmetric data object.
   \item \OPR{All-to-All}: All \acp{PE} participating in the routine exchange
       a fixed amount of contiguous or strided data with all other participating

--- a/content/programming_model_overview.tex
+++ b/content/programming_model_overview.tex
@@ -157,7 +157,7 @@ An overview of the \openshmem routines is described below:
       of concatenated symmetric objects contributed by each of the \acp{PE} in
       another symmetric data object.
   \item \OPR{Reduction}: All \acp{PE} participating in the routine get the result
-      of a binary operation over elements of the specified symmetric
+      of an associative binary routine over elements of the specified symmetric
       data object on another symmetric data object.
   \item \OPR{All-to-All}: All \acp{PE} participating in the routine exchange
       a fixed amount of contiguous or strided data with all other participating

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -373,7 +373,7 @@ where \TYPE{} is one of the integer, real, or complex types supported for the PR
 }
 
 \apireturnvalues{
-    Zero on successful local completion. Nonzero otherwise.
+  Zero on successful local completion. Nonzero otherwise.
 }
 
 \apinotes{

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -381,8 +381,7 @@ where \TYPE{} is one of the integer, real, or complex types supported for the PR
     associative and commutative.
     However, floating point arithmetic is not associative or commutative due to
     the inherent inaccuracies of floating-point representations caused by
-    rounding errors, finite precision, and the order of the applied binary
-    operations.
+    rounding errors and finite precision.
     This can lead to variations in the result of \openshmem arithmetic
     reduction operations on floating-point datatypes, including NaN values.
     A future version of the \openshmem specification may clarify the behavior

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -373,7 +373,20 @@ where \TYPE{} is one of the integer, real, or complex types supported for the PR
 }
 
 \apireturnvalues{
-  Zero on successful local completion. Nonzero otherwise.
+    Zero on successful local completion. Nonzero otherwise.
+}
+
+\apinotes{
+    The binary operations performed by \openshmem reductions are intended to be
+    associative and commutative.
+    However, floating point arithmetic is not associative or commutative due to
+    the inherent inaccuracies of floating-point representations caused by
+    rounding errors, finite precision, and the order of the applied binary
+    operations.
+    This can lead to variations in the result of \openshmem arithmetic
+    reduction operations on floating-point datatypes, including NaN values.
+    A future version of the \openshmem specification may clarify the behavior
+    of reductions on floating point datatypes.
 }
 
 \begin{apiexamples}


### PR DESCRIPTION
# Summary of changes
Regarding this issue:
https://github.com/orgs/openshmem-org/projects/5/views/1?pane=issue&itemId=74045800

The WG decided to defer something like PR https://github.com/davidozog/openshmem-specification/pull/14, which adds the requirements regarding the reproducibilty of OpenSHMEM reductions on floating-point datatypes.

This PR briefly explains the issue in an API note, and says a future version of the specification may clarify the behavior of reductions on floating-point datatypes.

# Proposal Checklist
- [X] Link to issue(s)
- [ ] Changelog entry
- [ ] Reviewed for changes to front matter
- [ ] Reviewed for changes to back matter
